### PR TITLE
Add "month" as another Duration constructor

### DIFF
--- a/src/Constants.elm
+++ b/src/Constants.elm
@@ -1,4 +1,4 @@
-module Constants exposing (acre, bushel, cubicFoot, cubicInch, cubicMeter, cubicYard, day, foot, hour, imperialFluidOunce, imperialGallon, imperialPint, imperialQuart, inch, liter, meter, mile, month, ounce, peck, pound, squareFoot, squareInch, squareMile, squareYard, usDryGallon, usDryPint, usDryQuart, usFluidOunce, usLiquidGallon, usLiquidPint, usLiquidQuart, week, yard)
+module Constants exposing (acre, bushel, cubicFoot, cubicInch, cubicMeter, cubicYard, day, foot, hour, imperialFluidOunce, imperialGallon, imperialPint, imperialQuart, inch, liter, meter, mile, month, ounce, peck, pound, squareFoot, squareInch, squareMile, squareYard, usDryGallon, usDryPint, usDryQuart, usFluidOunce, usLiquidGallon, usLiquidPint, usLiquidQuart, week, yard, year)
 
 {-| All conversion factors sourced from [National Institute of Standards and Technology (NIST)][1]
 unless otherwise specified.
@@ -216,3 +216,8 @@ week =
 month : Float
 month =
     2629746 * second
+
+
+year : Float
+year =
+    31557600 * second

--- a/src/Constants.elm
+++ b/src/Constants.elm
@@ -1,4 +1,4 @@
-module Constants exposing (acre, bushel, cubicFoot, cubicInch, cubicMeter, cubicYard, day, foot, hour, imperialFluidOunce, imperialGallon, imperialPint, imperialQuart, inch, liter, meter, mile, ounce, peck, pound, squareFoot, squareInch, squareMile, squareYard, usDryGallon, usDryPint, usDryQuart, usFluidOunce, usLiquidGallon, usLiquidPint, usLiquidQuart, week, yard)
+module Constants exposing (acre, bushel, cubicFoot, cubicInch, cubicMeter, cubicYard, day, foot, hour, imperialFluidOunce, imperialGallon, imperialPint, imperialQuart, inch, liter, meter, mile, month, ounce, peck, pound, squareFoot, squareInch, squareMile, squareYard, usDryGallon, usDryPint, usDryQuart, usFluidOunce, usLiquidGallon, usLiquidPint, usLiquidQuart, week, yard)
 
 {-| All conversion factors sourced from [National Institute of Standards and Technology (NIST)][1]
 unless otherwise specified.
@@ -211,3 +211,8 @@ day =
 week : Float
 week =
     7 * day
+
+
+month : Float
+month =
+    2629746 * second

--- a/src/Duration.elm
+++ b/src/Duration.elm
@@ -1,6 +1,7 @@
 module Duration exposing
     ( Duration, Seconds
     , from, seconds, inSeconds, milliseconds, inMilliseconds, minutes, inMinutes, hours, inHours, days, inDays, weeks, inWeeks, julianYears, inJulianYears
+    , inMonths, months
     )
 
 {-| A `Duration` refers to an elapsed time in seconds, milliseconds, hours etc.,
@@ -175,6 +176,28 @@ weeks numWeeks =
 inWeeks : Duration -> Float
 inWeeks duration =
     inSeconds duration / Constants.week
+
+
+{-| Construct a `Duration` from a given number of months.
+
+    Duration.months 2
+    --> Duration.days 60.87375
+
+-}
+months : Float -> Duration
+months numMonths =
+    seconds (Constants.month * numMonths)
+
+
+{-| Convert a `Duration` to a value in months.
+
+    Duration.days 31 |> Duration.inMonths
+    --> 1.0185014066
+
+-}
+inMonths : Duration -> Float
+inMonths duration =
+    inSeconds duration / Constants.month
 
 
 {-| Construct a `Duration` from a given number of [Julian years][julian_year].

--- a/src/Duration.elm
+++ b/src/Duration.elm
@@ -216,7 +216,7 @@ of a [light year](Length#lightYears).
 -}
 julianYears : Float -> Duration
 julianYears numJulianYears =
-    seconds (31557600 * numJulianYears)
+    seconds (Constants.year * numJulianYears)
 
 
 {-| Convert a `Duration` to a value in Julian years.
@@ -227,4 +227,4 @@ julianYears numJulianYears =
 -}
 inJulianYears : Duration -> Float
 inJulianYears duration =
-    inSeconds duration / 31557600
+    inSeconds duration / Constants.year

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -467,6 +467,7 @@ conversionsToQuantityAndBack =
             , fuzzFloatToQuantityAndBack "hours" Duration.hours Duration.inHours
             , fuzzFloatToQuantityAndBack "days" Duration.days Duration.inDays
             , fuzzFloatToQuantityAndBack "weeks" Duration.weeks Duration.inWeeks
+            , fuzzFloatToQuantityAndBack "months" Duration.months Duration.inMonths
             , fuzzFloatToQuantityAndBack "julianYears" Duration.julianYears Duration.inJulianYears
             ]
         , Test.describe "Energy" <|


### PR DESCRIPTION
Although the quantity of time in a month varies according to the month (obviously), one can use the total number of seconds in a year and divide by 12 to determine the average duration of a month.

Some examples:
```
> Duration.inJulianYears <| Duration.months 12
1 : Float
> Duration.inDays <| Duration.months 1
30.4375 : Float
> Duration.inWeeks <| Duration.months 1
4.348214285714286 : Float
```