### PR TITLE
Change elm-format version in travis to 0.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: elm
 elm: 0.19.0
-elm-format: 0.8.0
+elm-format: 0.8.1


### PR DESCRIPTION
Corrects version mismatch in `.travis.yml` with Contributing section.

Currently, the Contributing section in README.md states contributoIrs need to use `elm-format` version 0.8.1. 

I thought perhaps `0.8.0` was used deliberately. I've looked in the history of commits for [`.travis.yml`](https://github.com/ianmackenzie/elm-units/commits/master/.travis.yml) to determine if the `0.8.0` was used due to issues with the built-in support for Elm in Travis. It does not seem `0.8.1` has any known issues on the Travis platform (however, its' presence in the yml file might be indicating a desire to override - [hinted at here in Travis docs](https://docs.travis-ci.com/user/languages/elm/#environment-variables)). 