### PR TITLE
Add Molarity module

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Ian Mackenzie <ian.e.mackenzie@gmail.com>
 Matthias Devlamynck <matthias.devlamynck@mailoo.org>
 Katja Mordaunt <katjamordaunt@gmail.com>
 Karim Ulzhabayev <248163264@bk.ru>
+Andrew Lenards <andrew.lenards@gmail.com>

--- a/elm.json
+++ b/elm.json
@@ -24,6 +24,7 @@
         "LuminousFlux",
         "LuminousIntensity",
         "Mass",
+        "Molarity",
         "Pixels",
         "Power",
         "Pressure",

--- a/src/Constants.elm
+++ b/src/Constants.elm
@@ -1,4 +1,39 @@
-module Constants exposing (acre, bushel, cubicFoot, cubicInch, cubicMeter, cubicYard, day, foot, hour, imperialFluidOunce, imperialGallon, imperialPint, imperialQuart, inch, liter, meter, mile, ounce, peck, pound, squareFoot, squareInch, squareMile, squareYard, usDryGallon, usDryPint, usDryQuart, usFluidOunce, usLiquidGallon, usLiquidPint, usLiquidQuart, week, yard)
+module Constants exposing
+    ( acre
+    , bushel
+    , cubicFoot
+    , cubicInch
+    , cubicMeter
+    , cubicYard
+    , day
+    , foot
+    , hour
+    , imperialFluidOunce
+    , imperialGallon
+    , imperialPint
+    , imperialQuart
+    , inch
+    , liter
+    , meter
+    , mile
+    , mole
+    , ounce
+    , peck
+    , pound
+    , squareFoot
+    , squareInch
+    , squareMile
+    , squareYard
+    , usDryGallon
+    , usDryPint
+    , usDryQuart
+    , usFluidOunce
+    , usLiquidGallon
+    , usLiquidPint
+    , usLiquidQuart
+    , week
+    , yard
+    )
 
 {-| All conversion factors sourced from [National Institute of Standards and Technology (NIST)][1]
 unless otherwise specified.
@@ -211,3 +246,12 @@ day =
 week : Float
 week =
     7 * day
+
+
+
+---------- UNITS OF SUBSTANCE AMOUNT (in moles) ----------
+
+
+mole : Float
+mole =
+    1

--- a/src/Molarity.elm
+++ b/src/Molarity.elm
@@ -7,14 +7,15 @@ module Molarity exposing
     , micromolesPerLiter, inMicromolesPerLiter
     )
 
-{-| A `Molarity` value represents a concentration in mole per cubic meter, decimoles per liter, etc.
-It is stored in number of mole per cubic meter.
+{-| A `Molarity` value represents a concentration of substance in moles per
+cubic meter, moles per liter, millimoles per liter etc. It is stored as a number
+of moles per cubic meter.
 
-An SI unit, mole per cubic meter (mol/m3), `Molarity` is an amount of substance divided by the volume of the mixture.
-
-_Note: A liter is equal to a cubic decimeter._
-
-Section 8.6.5 in Chapter 8 of the [NIST Guide to the SI](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-8) does notes that the term molarity is consider obsolete. The initial decision to use `Molarity` as the module name was due to the verbosity of "amount-of-substance concentration".
+Note that the [NIST Guide to the
+SI](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-8)
+states that the term "molarity" is consider obsolete, but it appears to still be
+in common use and is far less verbose than the NIST suggestion of
+"amount-of-substance concentration".
 
 @docs Molarity, MolesPerCubicMeter
 @docs molesPerCubicMeter, inMolesPerCubicMeter

--- a/src/Molarity.elm
+++ b/src/Molarity.elm
@@ -14,8 +14,8 @@ of moles per cubic meter.
 
 Note that the [NIST Guide to the
 SI](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-8)
-states that the term "molarity" is consider obsolete, but it appears to still be
-in common use and is far less verbose than the NIST suggestion of
+states that the term "molarity" is considered obsolete, but it appears to still
+be in common use and is far less verbose than the alternative NIST suggestion of
 "amount-of-substance concentration".
 
 @docs Molarity, MolesPerCubicMeter

--- a/src/Molarity.elm
+++ b/src/Molarity.elm
@@ -1,6 +1,7 @@
 module Molarity exposing
     ( Molarity, MolesPerCubicMeter
     , molesPerCubicMeter, inMolesPerCubicMeter
+    , molesPerLiter, inMolesPerLiter
     , decimolesPerLiter, inDecimolesPerLiter
     , centimolesPerLiter, inCentimolesPerLiter
     , millimolesPerLiter, inMillimolesPerLiter
@@ -19,6 +20,7 @@ in common use and is far less verbose than the NIST suggestion of
 
 @docs Molarity, MolesPerCubicMeter
 @docs molesPerCubicMeter, inMolesPerCubicMeter
+@docs molesPerLiter, inMolesPerLiter
 @docs decimolesPerLiter, inDecimolesPerLiter
 @docs centimolesPerLiter, inCentimolesPerLiter
 @docs millimolesPerLiter, inMillimolesPerLiter
@@ -76,6 +78,20 @@ molesPerCubicMeter numMolesPerCubicMeter =
 inMolesPerCubicMeter : Molarity -> Float
 inMolesPerCubicMeter (Quantity numMolesPerCubicMeter) =
     numMolesPerCubicMeter
+
+
+{-| Construct a molarity from a number of moles per liter.
+-}
+molesPerLiter : Float -> Molarity
+molesPerLiter numMolesPerLiter =
+    molesPerCubicMeter (numMolesPerLiter * oneMolePerLiter)
+
+
+{-| Convert a molarity to a number of moles per liter.
+-}
+inMolesPerLiter : Molarity -> Float
+inMolesPerLiter molarity =
+    inMolesPerCubicMeter molarity / oneMolePerLiter
 
 
 {-| Construct a molarity from a number of decimoles per liter.

--- a/src/Molarity.elm
+++ b/src/Molarity.elm
@@ -18,6 +18,22 @@ states that the term "molarity" is considered obsolete, but it appears to still
 be in common use and is far less verbose than the alternative NIST suggestion of
 "amount-of-substance concentration".
 
+Since the units of `Molarity` are defined to be `Rate Moles CubicMeters` (amount
+of substance per unit volume), you can construct a `Molarity` value using
+`Quantity.per`:
+
+    molarity =
+        substanceAmount |> Quantity.per volume
+
+You can also do rate-related calculations with `Molarity` values to compute
+`SubstanceAmount` or `Volume`:
+
+    substanceAmount =
+        volume |> Quantity.at molarity
+
+    volume =
+        substanceAmount |> Quantity.at_ molarity
+
 @docs Molarity, MolesPerCubicMeter
 @docs molesPerCubicMeter, inMolesPerCubicMeter
 @docs molesPerLiter, inMolesPerLiter

--- a/src/Molarity.elm
+++ b/src/Molarity.elm
@@ -1,0 +1,110 @@
+module Molarity exposing
+    ( Molarity, MolesPerCubicMeter
+    , molesPerCubicMeter, inMolesPerCubicMeter
+    , decimolesPerLiter, inDecimolesPerLiter
+    , centimolesPerLiter, inCentimolesPerLiter
+    , millimolesPerLiter, inMillimolesPerLiter
+    , micromolesPerLiter, inMicromolesPerLiter
+    )
+
+{-| A `Molarity` value represents a concentration in mole per cubic meter, decimoles per liter, etc.
+It is stored in number of mole per cubic meter.
+
+An SI unit, mole per cubic meter (mol/m3), `Molarity` is an amount of substance divided by the volume of the mixture.
+
+_Note: A liter is equal to a cubic decimeter._
+
+Section 8.6.5 in Chapter 8 of the [NIST Guide to the SI](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-8) does notes that the term molarity is consider obsolete. The initial decision to use `Molarity` as the module name was due to the verbosity of "amount-of-substance concentration".
+
+@docs Molarity, MolesPerCubicMeter
+@docs molesPerCubicMeter, inMolesPerCubicMeter
+@docs decimolesPerLiter, inDecimolesPerLiter
+@docs centimolesPerLiter, inCentimolesPerLiter
+@docs millimolesPerLiter, inMillimolesPerLiter
+@docs micromolesPerLiter, inMicromolesPerLiter
+
+-}
+
+import Quantity exposing (Quantity(..), Rate)
+import SubstanceAmount exposing (Moles)
+import Volume exposing (CubicMeters)
+
+
+{-| -}
+type alias MolesPerCubicMeter =
+    Rate Moles CubicMeters
+
+
+{-| -}
+type alias Molarity =
+    Quantity Float MolesPerCubicMeter
+
+
+{-| Construct a molarity from a number of moles per cubic meter.
+-}
+molesPerCubicMeter : Float -> Molarity
+molesPerCubicMeter numMolesPerCubicMeter =
+    Quantity numMolesPerCubicMeter
+
+
+{-| Convert a molarity to a number of moles per cubic meter.
+-}
+inMolesPerCubicMeter : Molarity -> Float
+inMolesPerCubicMeter (Quantity numMolesPerCubicMeter) =
+    numMolesPerCubicMeter
+
+
+{-| Construct a molarity from a number of decimoles per liter.
+-}
+decimolesPerLiter : Float -> Molarity
+decimolesPerLiter numDecimolesPerLiter =
+    molesPerCubicMeter (10 * numDecimolesPerLiter)
+
+
+{-| Convert a molarity to a number of decimoles per liter.
+-}
+inDecimolesPerLiter : Molarity -> Float
+inDecimolesPerLiter (Quantity numMolesPerCubicMeter) =
+    numMolesPerCubicMeter / 10
+
+
+{-| Construct a molarity from a number of centimoles per liter.
+-}
+centimolesPerLiter : Float -> Molarity
+centimolesPerLiter numCentimolesPerLiter =
+    decimolesPerLiter (10 * numCentimolesPerLiter)
+
+
+{-| Convert a molarity to a number of centimoles per liter.
+-}
+inCentimolesPerLiter : Molarity -> Float
+inCentimolesPerLiter molar =
+    inDecimolesPerLiter molar / 10
+
+
+{-| Construct a molarity from a number of millimoles per liter.
+-}
+millimolesPerLiter : Float -> Molarity
+millimolesPerLiter numMillimolesPerLiter =
+    decimolesPerLiter (100 * numMillimolesPerLiter)
+
+
+{-| Convert a molarity to a number of millimoles per liter.
+-}
+inMillimolesPerLiter : Molarity -> Float
+inMillimolesPerLiter molar =
+    inDecimolesPerLiter molar / 100
+
+
+{-| Construct a molarity from a number of micromoles per liter.
+-}
+micromolesPerLiter : Float -> Molarity
+micromolesPerLiter numMicromolesPerLiter =
+    decimolesPerLiter (1000 * numMicromolesPerLiter)
+
+
+{-| Convert a molarity to a number of micromoles per liter.
+-}
+inMicromolesPerLiter : Molarity -> Float
+inMicromolesPerLiter molar =
+    inDecimolesPerLiter molar / 1000

--- a/src/Molarity.elm
+++ b/src/Molarity.elm
@@ -26,6 +26,7 @@ in common use and is far less verbose than the NIST suggestion of
 
 -}
 
+import Constants
 import Quantity exposing (Quantity(..), Rate)
 import SubstanceAmount exposing (Moles)
 import Volume exposing (CubicMeters)
@@ -39,6 +40,28 @@ type alias MolesPerCubicMeter =
 {-| -}
 type alias Molarity =
     Quantity Float MolesPerCubicMeter
+
+
+
+---------- CONSTANTS ----------
+
+
+{-| One mole per liter, in moles per cubic meter
+-}
+oneMolePerLiter : Float
+oneMolePerLiter =
+    Constants.mole / Constants.liter
+
+
+{-| One decimole per liter, in moles per cubic meter
+-}
+oneDecimolePerLiter : Float
+oneDecimolePerLiter =
+    0.1 * Constants.mole / Constants.liter
+
+
+
+---------- FUNCTIONS ----------
 
 
 {-| Construct a molarity from a number of moles per cubic meter.
@@ -59,14 +82,14 @@ inMolesPerCubicMeter (Quantity numMolesPerCubicMeter) =
 -}
 decimolesPerLiter : Float -> Molarity
 decimolesPerLiter numDecimolesPerLiter =
-    molesPerCubicMeter (10 * numDecimolesPerLiter)
+    molesPerCubicMeter (numDecimolesPerLiter * oneDecimolePerLiter)
 
 
 {-| Convert a molarity to a number of decimoles per liter.
 -}
 inDecimolesPerLiter : Molarity -> Float
-inDecimolesPerLiter (Quantity numMolesPerCubicMeter) =
-    numMolesPerCubicMeter / 10
+inDecimolesPerLiter molarity =
+    inMolesPerCubicMeter molarity / oneDecimolePerLiter
 
 
 {-| Construct a molarity from a number of centimoles per liter.

--- a/src/SubstanceAmount.elm
+++ b/src/SubstanceAmount.elm
@@ -1,8 +1,9 @@
 module SubstanceAmount exposing
     ( SubstanceAmount, Moles
     , moles, inMoles, picomoles, inPicomoles, nanomoles, inNanomoles
-    , micromoles, inMicromoles, millimoles, inMillimoles, kilomoles, inKilomoles
-    , megamoles, inMegamoles, gigamoles, inGigamoles
+    , micromoles, inMicromoles, millimoles, inMillimoles
+    , centimoles, inCentimoles, decimoles, inDecimoles
+    , kilomoles, inKilomoles, megamoles, inMegamoles, gigamoles, inGigamoles
     )
 
 {-| A `SubstanceAmount` value represents a substance amount in [moles][1].
@@ -15,8 +16,9 @@ module SubstanceAmount exposing
 ## Conversions
 
 @docs moles, inMoles, picomoles, inPicomoles, nanomoles, inNanomoles
-@docs micromoles, inMicromoles, millimoles, inMillimoles, kilomoles, inKilomoles
-@docs megamoles, inMegamoles, gigamoles, inGigamoles
+@docs micromoles, inMicromoles, millimoles, inMillimoles
+@docs centimoles, inCentimoles, decimoles, inDecimoles
+@docs kilomoles, inKilomoles, megamoles, inMegamoles, gigamoles, inGigamoles
 
 -}
 
@@ -101,6 +103,34 @@ millimoles numMillimoles =
 inMillimoles : SubstanceAmount -> Float
 inMillimoles substanceAmount =
     inMoles substanceAmount / 1.0e-3
+
+
+{-| Construct a substance amount from a number of centimoles.
+-}
+centimoles : Float -> SubstanceAmount
+centimoles numCentimoles =
+    moles (numCentimoles * 1.0e-2)
+
+
+{-| Convert a substance amount to a number of centimoles.
+-}
+inCentimoles : SubstanceAmount -> Float
+inCentimoles substanceAmount =
+    inMoles substanceAmount / 1.0e-2
+
+
+{-| Construct a substance amount from a number of decimoles.
+-}
+decimoles : Float -> SubstanceAmount
+decimoles numDecimoles =
+    moles (numDecimoles * 1.0e-1)
+
+
+{-| Convert a substance amount to a number of decimoles.
+-}
+inDecimoles : SubstanceAmount -> Float
+inDecimoles substanceAmount =
+    inMoles substanceAmount / 1.0e-1
 
 
 {-| Construct a substance amount from a number of kilomoles.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -242,8 +242,17 @@ substanceAmount =
         , ( nanomoles 1000000
           , millimoles 1
           )
+        , ( centimoles 600
+          , decimoles 60
+          )
         , ( moles 1
           , millimoles 1000
+          )
+        , ( moles 4
+          , centimoles 400
+          )
+        , ( moles 2
+          , decimoles 20
           )
         , ( moles 2000
           , kilomoles 2
@@ -575,6 +584,8 @@ conversionsToQuantityAndBack =
             , fuzzFloatToQuantityAndBack "nanomoles" SubstanceAmount.nanomoles SubstanceAmount.inNanomoles
             , fuzzFloatToQuantityAndBack "micromoles" SubstanceAmount.micromoles SubstanceAmount.inMicromoles
             , fuzzFloatToQuantityAndBack "millimoles" SubstanceAmount.millimoles SubstanceAmount.inMillimoles
+            , fuzzFloatToQuantityAndBack "centimoles" SubstanceAmount.centimoles SubstanceAmount.inCentimoles
+            , fuzzFloatToQuantityAndBack "decimoles" SubstanceAmount.decimoles SubstanceAmount.inDecimoles
             , fuzzFloatToQuantityAndBack "kilomoles" SubstanceAmount.kilomoles SubstanceAmount.inKilomoles
             , fuzzFloatToQuantityAndBack "megamoles" SubstanceAmount.megamoles SubstanceAmount.inMegamoles
             , fuzzFloatToQuantityAndBack "gigamoles" SubstanceAmount.gigamoles SubstanceAmount.inGigamoles

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -230,7 +230,13 @@ substanceAmount =
     equalPairs
         "SubstanceAmounts"
         "ν"
-        [ ( millimoles 3
+        [ ( nanomoles 20
+          , picomoles 20000
+          )
+        , ( nanomoles 7000
+          , micromoles 7
+          )
+        , ( millimoles 3
           , micromoles 3000
           )
         , ( nanomoles 1000000

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -46,6 +46,7 @@ import Luminance
 import LuminousFlux
 import LuminousIntensity
 import Mass exposing (..)
+import Molarity exposing (..)
 import Pixels exposing (..)
 import Power exposing (..)
 import Pressure exposing (..)
@@ -524,6 +525,13 @@ conversionsToQuantityAndBack =
             , fuzzFloatToQuantityAndBack "metricTons" Mass.metricTons Mass.inMetricTons
             , fuzzFloatToQuantityAndBack "shortTons" Mass.shortTons Mass.inShortTons
             , fuzzFloatToQuantityAndBack "longTons" Mass.longTons Mass.inLongTons
+            ]
+        , Test.describe "Molarity" <|
+            [ fuzzFloatToQuantityAndBack "molesPerCubicMeter" Molarity.molesPerCubicMeter Molarity.inMolesPerCubicMeter
+            , fuzzFloatToQuantityAndBack "decimolesPerLiter" Molarity.decimolesPerLiter Molarity.inDecimolesPerLiter
+            , fuzzFloatToQuantityAndBack "centimolesPerLiter" Molarity.centimolesPerLiter Molarity.inCentimolesPerLiter
+            , fuzzFloatToQuantityAndBack "millimolesPerLiter" Molarity.millimolesPerLiter Molarity.inMillimolesPerLiter
+            , fuzzFloatToQuantityAndBack "micromolesPerLiter" Molarity.micromolesPerLiter Molarity.inMicromolesPerLiter
             ]
         , Test.describe "Pixels" <|
             [ fuzzFloatToQuantityAndBack "pixels" Pixels.pixels Pixels.inPixels


### PR DESCRIPTION
Relates to #6. 
Applies feedback from #42. 

## Work Done

In `SubstanceAmount` module:
- [x] define `decimoles`, `inDecimoles`, `centimoles`, `inCentimoles`
- [x] define Fuzzing test entries for what was added
- [x] confirm _millimoles_ and _micromoles_ functions are tested already 

In `Molarity` module:
- [x] define all of the following
     - [x] `molesPerLiter`, `inMolesPerLiter`
     - [x] `decimolesPerLiter`, `inDecimolesPerLiter`
     - [x] `centimolesPerLiter`, `inCentimolesPerLiter`
     - [x] `millimolesPerLiter`, `inMillimolesPerLiter`
     - [x] `micromolesPerLiter`, `inMicromolesPerLiter`
- [x] define Fuzzing test entries for what was added

## What Is Missing? 

### `molesPerLiter`, `inMolesPerLiter`

Because `Molarity` is defining the value as a `Rate`, and there is not direct access to a numerator and denomerator, I am not sure what that because what to define `molesPerLiter` given `molesPerCubicMeter` and/or `decimolesPerLiter`. 

### A good example in the module comment

My lack of familiarity with concentration, or amount-of-substance of concentration, means that I'm not sure what a good _usage_ example would be to include in the module comment. I would appreciate thoughts, suggestions, etc. 

## Thank you

I appreciate the feedback on the draft pull request, see #42. Thank you for your time in considering this contribution. 

