### PR TITLE
Adds angstrom and nanometer to Length with corresponding tests.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Matthias Devlamynck <matthias.devlamynck@mailoo.org>
 Katja Mordaunt <katjamordaunt@gmail.com>
 Karim Ulzhabayev <248163264@bk.ru>
 Andrew Lenards <andrew.lenards@gmail.com>
+Chris Wells Wood <cwwoodesq@gmail.com>

--- a/src/Length.elm
+++ b/src/Length.elm
@@ -1,13 +1,14 @@
 module Length exposing
     ( Length, Meters
     , meters, inMeters
-    , microns, inMicrons, millimeters, inMillimeters, centimeters, inCentimeters, kilometers, inKilometers
+    , inAngstroms, nanometers, inNanometers, microns, inMicrons, millimeters, inMillimeters, centimeters, inCentimeters, kilometers, inKilometers
     , thou, inThou, inches, inInches, feet, inFeet, yards, inYards, miles, inMiles
     , cssPixels, inCssPixels, points, inPoints, picas, inPicas
     , astronomicalUnits, inAstronomicalUnits, parsecs, inParsecs, lightYears, inLightYears
     , meter, micron, millimeter, centimeter, kilometer
     , inch, foot, yard, mile
     , astronomicalUnit, parsec, lightYear
+    , angstrom, angstroms, nanometer
     )
 
 {-| A `Length` represents a length in meters, feet, centimeters, miles etc. It
@@ -19,7 +20,7 @@ is stored as a number of meters.
 ## Metric
 
 @docs meters, inMeters
-@docs microns, inMicrons, millimeters, inMillimeters, centimeters, inCentimeters, kilometers, inKilometers
+@docs angtroms, inAngstroms, nanometers, inNanometers, microns, inMicrons, millimeters, inMillimeters, centimeters, inCentimeters, kilometers, inKilometers
 
 
 ## Imperial
@@ -86,6 +87,50 @@ meters numMeters =
 inMeters : Length -> Float
 inMeters (Quantity numMeters) =
     numMeters
+
+
+{-| Construct a length from a number of angstroms.
+
+    Length.angstroms 1
+    --> Length.meters 1e-10
+
+-}
+angstroms : Float -> Length
+angstroms numAngstroms =
+    meters (1.0e-10 * numAngstroms)
+
+
+{-| Convert a length to a number of angstroms.
+
+    Length.nanometers 1 |> Length.inAngstroms
+    --> 10
+
+-}
+inAngstroms : Length -> Float
+inAngstroms length =
+    1.0e10 * inMeters length
+
+
+{-| Construct a length from a number of nanometers.
+
+    Length.nanometers 1
+    --> Length.meters 1e-9
+
+-}
+nanometers : Float -> Length
+nanometers numNanometers =
+    meters (1.0e-9 * numNanometers)
+
+
+{-| Convert a length to a number of nanometers.
+
+    Length.microns 1 |> Length.inNanometers
+    --> 1000
+
+-}
+inNanometers : Length -> Float
+inNanometers length =
+    1.0e9 * inMeters length
 
 
 {-| Construct a length from a number of microns (micrometers).
@@ -346,6 +391,18 @@ inLightYears length =
 meter : Length
 meter =
     meters 1
+
+
+{-| -}
+angstrom : Length
+angstrom =
+    angstroms 1
+
+
+{-| -}
+nanometer : Length
+nanometer =
+    nanometers 1
 
 
 {-| -}

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -124,6 +124,12 @@ lengths =
         , ( meters 1
           , microns 1.0e6
           )
+        , ( angstroms 2.0e10
+          , meters 2
+          )
+        , ( nanometers 1
+          , angstroms 10
+          )
         , ( cssPixels 1
           , inches (1 / 96)
           )


### PR DESCRIPTION
I work with very small stuff, so I added nanometers as well as [angstroms](https://en.wikipedia.org/wiki/Angstrom), which are equal to 1e-10 m. Angstroms (Å) are used widely in structural biology and chemistry, as they are convenient for describing distances at the atomic scale. For example, 1 Å is quite close to most chemical bond lengths.