### PR TITLE
 Add cubicCentimeters to Volume module

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Katja Mordaunt <katjamordaunt@gmail.com>
 Karim Ulzhabayev <248163264@bk.ru>
 Andrew Lenards <andrew.lenards@gmail.com>
 Chris Wells Wood <cwwoodesq@gmail.com>
+Guilherme Riekes Belmonte <contact@belmonte.dev>

--- a/src/Volume.elm
+++ b/src/Volume.elm
@@ -1,13 +1,13 @@
 module Volume exposing
     ( Volume, CubicMeters
-    , cubicMeters, inCubicMeters, cubicCentimeters, inCubicCentimeters
-    , milliliters, inMilliliters, liters, inLiters
+    , cubicMeters, inCubicMeters
+    , milliliters, inMilliliters, liters, inLiters, cubicCentimeters, inCubicCentimeters
     , cubicInches, inCubicInches, cubicFeet, inCubicFeet, cubicYards, inCubicYards
     , usLiquidGallons, inUsLiquidGallons, usDryGallons, inUsDryGallons, imperialGallons, inImperialGallons
     , usLiquidQuarts, inUsLiquidQuarts, usDryQuarts, inUsDryQuarts, imperialQuarts, inImperialQuarts
     , usLiquidPints, inUsLiquidPints, usDryPints, inUsDryPints, imperialPints, inImperialPints
     , usFluidOunces, inUsFluidOunces, imperialFluidOunces, inImperialFluidOunces
-    , cubicMeter, milliliter, liter
+    , cubicMeter, milliliter, liter, cubicCentimeter
     , cubicInch, cubicFoot, cubicYard
     , usLiquidGallon, usDryGallon, imperialGallon
     , usLiquidQuart, usDryQuart, imperialQuart
@@ -25,7 +25,7 @@ meters.
 ## Metric
 
 @docs cubicMeters, inCubicMeters
-@docs milliliters, inMilliliters, liters, inLiters
+@docs milliliters, inMilliliters, liters, inLiters, cubicCentimeters, inCubicCentimeters
 
 
 ## Imperial
@@ -42,7 +42,7 @@ meters.
 Shorthand for `Volume.cubicMeters 1`, `Volume.imperialGallons 1` etc. Can be
 convenient to use with [`Quantity.per`](Quantity#per).
 
-@docs cubicMeter, milliliter, liter
+@docs cubicMeter, milliliter, liter, cubicCentimeter
 @docs cubicInch, cubicFoot, cubicYard
 @docs usLiquidGallon, usDryGallon, imperialGallon
 @docs usLiquidQuart, usDryQuart, imperialQuart

--- a/src/Volume.elm
+++ b/src/Volume.elm
@@ -80,20 +80,6 @@ inCubicMeters (Quantity numCubicMeters) =
     numCubicMeters
 
 
-{-| Construct a volume from a number of cubic centimeters.
--}
-cubicCentimeters : Float -> Volume
-cubicCentimeters numCubicCentimeters =
-    milliliters numCubicCentimeters
-
-
-{-| Convert a volume to a number of cubic centimeters.
--}
-inCubicCentimeters : Volume -> Float
-inCubicCentimeters volume =
-    inMilliliters volume
-
-
 {-| Construct a volume from a number of cubic inches.
 -}
 cubicInches : Float -> Volume
@@ -148,6 +134,23 @@ milliliters numMilliliters =
 inMilliliters : Volume -> Float
 inMilliliters volume =
     1.0e6 * inCubicMeters volume
+
+
+{-| Construct a volume from a number of cubic centimeters.
+Alias for `milliliters`.
+
+-}
+cubicCentimeters : Float -> Volume
+cubicCentimeters numCubicCentimeters =
+    milliliters numCubicCentimeters
+
+
+{-| Convert a volume to a number of cubic centimeters.
+Alias for `inMilliliters`.
+-}
+inCubicCentimeters : Volume -> Float
+inCubicCentimeters volume =
+    inMilliliters volume
 
 
 {-| Construct a volume from a number of liters.

--- a/src/Volume.elm
+++ b/src/Volume.elm
@@ -1,6 +1,6 @@
 module Volume exposing
     ( Volume, CubicMeters
-    , cubicMeters, inCubicMeters
+    , cubicMeters, inCubicMeters, cubicCentimeters, inCubicCentimeters
     , milliliters, inMilliliters, liters, inLiters
     , cubicInches, inCubicInches, cubicFeet, inCubicFeet, cubicYards, inCubicYards
     , usLiquidGallons, inUsLiquidGallons, usDryGallons, inUsDryGallons, imperialGallons, inImperialGallons
@@ -78,6 +78,20 @@ cubicMeters numCubicMeters =
 inCubicMeters : Volume -> Float
 inCubicMeters (Quantity numCubicMeters) =
     numCubicMeters
+
+
+{-| Construct a volume from a number of cubic centimeters.
+-}
+cubicCentimeters : Float -> Volume
+cubicCentimeters numCubicCentimeters =
+    milliliters numCubicCentimeters
+
+
+{-| Convert a volume to a number of cubic centimeters.
+-}
+inCubicCentimeters : Volume -> Float
+inCubicCentimeters numCubicCentimeters =
+    inMilliliters numCubicCentimeters
 
 
 {-| Construct a volume from a number of cubic inches.

--- a/src/Volume.elm
+++ b/src/Volume.elm
@@ -90,8 +90,8 @@ cubicCentimeters numCubicCentimeters =
 {-| Convert a volume to a number of cubic centimeters.
 -}
 inCubicCentimeters : Volume -> Float
-inCubicCentimeters numCubicCentimeters =
-    inMilliliters numCubicCentimeters
+inCubicCentimeters volume =
+    inMilliliters volume
 
 
 {-| Construct a volume from a number of cubic inches.

--- a/src/Volume.elm
+++ b/src/Volume.elm
@@ -138,7 +138,6 @@ inMilliliters volume =
 
 {-| Construct a volume from a number of cubic centimeters.
 Alias for `milliliters`.
-
 -}
 cubicCentimeters : Float -> Volume
 cubicCentimeters numCubicCentimeters =
@@ -330,6 +329,12 @@ cubicMeter =
 {-| -}
 milliliter : Volume
 milliliter =
+    milliliters 1
+
+
+{-| -}
+cubicCentimeter : Volume
+cubicCentimeter =
     milliliters 1
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -383,6 +383,9 @@ volumes =
         , ( imperialPints 1
           , imperialFluidOunces 20
           )
+        , ( cubicCentimeters 1
+          , milliliters 1
+          )
         ]
 
 
@@ -625,6 +628,7 @@ conversionsToQuantityAndBack =
             ]
         , Test.describe "Volume" <|
             [ fuzzFloatToQuantityAndBack "cubicMeters" Volume.cubicMeters Volume.inCubicMeters
+            , fuzzFloatToQuantityAndBack "cubicCentimeters" Volume.cubicCentimeters Volume.inCubicCentimeters
             , fuzzFloatToQuantityAndBack "cubicInches" Volume.cubicInches Volume.inCubicInches
             , fuzzFloatToQuantityAndBack "cubicFeet" Volume.cubicFeet Volume.inCubicFeet
             , fuzzFloatToQuantityAndBack "cubicYards" Volume.cubicYards Volume.inCubicYards


### PR DESCRIPTION
Hey there, @ianmackenzie !

I opened this MR implementing the cubic centimeters as an alias of milliliters, as I understood from https://github.com/ianmackenzie/elm-units/issues/52

Let me know your thoughts :smile: 