### PR TITLE
Adds torque module

### DIFF
--- a/src/Constants.elm
+++ b/src/Constants.elm
@@ -394,4 +394,4 @@ newtonMeter =
 
 poundFoot : Float
 poundFoot =
-    poundForce * foot * newtonMeter
+    poundForce * foot

--- a/src/Constants.elm
+++ b/src/Constants.elm
@@ -28,6 +28,7 @@ module Constants exposing
     , mile
     , mole
     , newton
+    , newtonMeter
     , ounce
     , parsec
     , pascal
@@ -35,6 +36,7 @@ module Constants exposing
     , pica
     , point
     , pound
+    , poundFoot
     , poundForce
     , shortTon
     , squareFoot
@@ -379,3 +381,17 @@ atmosphere =
 pascal : Float
 pascal =
     newton / (meter * meter)
+
+
+
+-------- UNITS OF TORQUE (in newton-meters) ---------
+
+
+newtonMeter : Float
+newtonMeter =
+    newton * meter
+
+
+poundFoot : Float
+poundFoot =
+    poundForce * foot * newtonMeter

--- a/src/Torque.elm
+++ b/src/Torque.elm
@@ -59,11 +59,11 @@ inNewtonMeters (Quantity numNewtonMeters) =
 -}
 poundFeet : Float -> Torque
 poundFeet numPoundFeet =
-    newtonMeters (Constants.poundForce * Constants.foot * numPoundFeet)
+    newtonMeters (Constants.poundFoot * numPoundFeet)
 
 
 {-| Convert a torque value to a number of pound-feet (sometimes called foot-pounds).
 -}
 inPoundFeet : Torque -> Float
 inPoundFeet torque =
-    inNewtonMeters torque / (Constants.poundForce * Constants.foot)
+    inNewtonMeters torque / Constants.poundFoot

--- a/src/Torque.elm
+++ b/src/Torque.elm
@@ -1,0 +1,69 @@
+module Torque exposing
+    ( Torque, NewtonMeters
+    , newtonMeters, inNewtonMeters
+    , poundFeet, inPoundFeet
+    )
+
+{-| Torque is the rotational analogue of linear force. It is also referred to as the moment of force (also abbreviated to moment).
+It describes the rate of change of angular momentum that would be imparted to an isolated body.
+
+@docs Torque, NewtonMeters
+
+
+## Metric
+
+@docs newtonMeters, inNewtonMeters
+
+
+## Imperial
+
+@docs poundFeet, inPoundFeet
+
+-}
+
+import Constants
+import Force exposing (Newtons)
+import Length exposing (Meters)
+import Quantity exposing (Product, Quantity(..))
+
+
+{-| NB: You may notice that the type here is exactly the same as for `Energy.Joules`.
+
+This means the type checker will not help you in distinguishing between these units.
+
+-}
+type alias NewtonMeters =
+    Product Newtons Meters
+
+
+{-| -}
+type alias Torque =
+    Quantity Float NewtonMeters
+
+
+{-| Construct a torque value from a number of newton-meters.
+-}
+newtonMeters : Float -> Torque
+newtonMeters numNewtonMeters =
+    Quantity numNewtonMeters
+
+
+{-| Convert a torque value to a number of newton-meters.
+-}
+inNewtonMeters : Torque -> Float
+inNewtonMeters (Quantity numNewtonMeters) =
+    numNewtonMeters
+
+
+{-| Construct a torque value from a number of pound-feet (sometimes called foot-pounds).
+-}
+poundFeet : Float -> Torque
+poundFeet numPoundFeet =
+    newtonMeters (Constants.poundForce * Constants.foot * numPoundFeet)
+
+
+{-| Convert a torque value to a number of pound-feet (sometimes called foot-pounds).
+-}
+inPoundFeet : Torque -> Float
+inPoundFeet torque =
+    inNewtonMeters torque / (Constants.poundForce * Constants.foot)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -30,6 +30,7 @@ module Tests exposing
     , times
     , toDmsProducesValidValues
     , toDmsReconstructsAngle
+    , torques
     , volumes
     )
 
@@ -67,6 +68,7 @@ import SubstanceAmount exposing (..)
 import Temperature exposing (Temperature)
 import Test exposing (Test)
 import Time
+import Torque exposing (newtonMeters, poundFeet)
 import Voltage exposing (..)
 import Volume exposing (..)
 
@@ -345,6 +347,13 @@ temperatureDeltas =
           , Temperature.fahrenheitDegrees 23
           )
         ]
+
+
+torques : Test
+torques =
+    equalPairs "Torques"
+        "Nm"
+        [ ( newtonMeters 1, poundFeet 0.7375621492772654 ) ]
 
 
 volumes : Test


### PR DESCRIPTION
Adding a log of some Slack conversations about some design decisions:

> @gampleman 
> I’m considering contributing a Torque module to elm-units, but wondering about the definition. The standard unit is the Newton-Metre, which one would normally write as type alias NewtonMeters = Product Newtons Meters. This is however identical to type alias Joules = Product Newtons Meters , so the compiler won’t complain if those quantities are ever confused (and they are different physics concepts).  [There seems to be some ideas](https://physics.stackexchange.com/questions/37881/why-is-torque-not-measured-in-joules) of defining them as Ratio Joules Radians, which makes some sense, but might be confusing (and also unclear on how to call this unit).

> @ianmackenzie 
> My first reaction would be to just use 'Product Newton Meters' and accept the risk of confusing a torque value for a force one, but the ratio idea is interesting
> It would probably be useful to see what a few reasonable kinds of calculations would look like in each form
> Like obviously "compute a torque from a force and radius" is easier in one version and "compute energy from torque and angle" is easier in the other version, but what does it look like to do, say, each of those calculations using the 'wrong' representation
That said I suspect a common use of torque would be with elm-physics and similar simulations, in which case I think the 'Product Newtons Meters' version would likely be a better fit
Also some relevant discussion/thoughts in https://github.com/ianmackenzie/elm-units/issues/32


> @gampleman 
> At the moment we’re not really doing any calculations, we’re mostly using it as a way to not mix up our units. So I don’t have much perspective on this.

> @ianmackenzie 
> I think the most straightforward answer for now is to just use 'type alias NewtonMeters = Product Newtons Meters' and accept that that will be indistinguishable from Joules...in the long term I think it could indeed be good to take the approach discussed in https://github.com/ianmackenzie/elm-units/issues/32 and have every unit type be its own custom type by default, with explicit conversions to product/ratio form as needed